### PR TITLE
Add progress only mode for info command (#60)

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -344,6 +344,14 @@ option:
     command-role:
       main: {}
 
+  progress-only:
+    type: boolean
+    default: false
+    command:
+      info: {}
+    command-role:
+      main: {}
+
   reference:
     type: string
     required: false

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -2582,6 +2582,17 @@
                         <example>json</example>
                     </option>
 
+                    <option id="progress-only" name="Progress Only">
+                        <summary>Get only progress information.</summary>
+
+                        <text>
+                            <p>Specifying this option as true displays only the progress details of the backup/expire process. As it skips repository access, it speeds up retrieving such information.</p>
+                            <p>Note that the info command with this option does not perform any additional checks, except for the availability of the stanza. To obtain comprehensive information, use the full version of the info command.</p>
+                        </text>
+
+                        <example>y</example>
+                    </option>
+
                     <option id="set" name="Set">
                         <summary>Backup set to detail.</summary>
 

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -103,6 +103,7 @@ Option constants
 #define CFGOPT_PG_VERSION_FORCE                                     "pg-version-force"
 #define CFGOPT_PROCESS                                              "process"
 #define CFGOPT_PROCESS_MAX                                          "process-max"
+#define CFGOPT_PROGRESS_ONLY                                        "progress-only"
 #define CFGOPT_PROTOCOL_TIMEOUT                                     "protocol-timeout"
 #define CFGOPT_RAW                                                  "raw"
 #define CFGOPT_RECOVERY_OPTION                                      "recovery-option"
@@ -140,7 +141,7 @@ Option constants
 #define CFGOPT_VERBOSE                                              "verbose"
 #define CFGOPT_VERSION                                              "version"
 
-#define CFG_OPTION_TOTAL                                            185
+#define CFG_OPTION_TOTAL                                            186
 
 /***********************************************************************************************************************************
 Option value constants
@@ -471,6 +472,7 @@ typedef enum
     cfgOptPgVersionForce,
     cfgOptProcess,
     cfgOptProcessMax,
+    cfgOptProgressOnly,
     cfgOptProtocolTimeout,
     cfgOptRaw,
     cfgOptRecoveryOption,

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -4656,6 +4656,30 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                        // opt/process-max
     ),                                                                                                            // opt/process-max
     // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                           // opt/progress-only
+    (                                                                                                           // opt/progress-only
+        PARSE_RULE_OPTION_NAME("progress-only"),                                                                // opt/progress-only
+        PARSE_RULE_OPTION_TYPE(Boolean),                                                                        // opt/progress-only
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                       // opt/progress-only
+        PARSE_RULE_OPTION_SECTION(CommandLine),                                                                 // opt/progress-only
+                                                                                                                // opt/progress-only
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                          // opt/progress-only
+        (                                                                                                       // opt/progress-only
+            PARSE_RULE_OPTION_COMMAND(Info)                                                                     // opt/progress-only
+        ),                                                                                                      // opt/progress-only
+                                                                                                                // opt/progress-only
+        PARSE_RULE_OPTIONAL                                                                                     // opt/progress-only
+        (                                                                                                       // opt/progress-only
+            PARSE_RULE_OPTIONAL_GROUP                                                                           // opt/progress-only
+            (                                                                                                   // opt/progress-only
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                     // opt/progress-only
+                (                                                                                               // opt/progress-only
+                    PARSE_RULE_VAL_BOOL_FALSE,                                                                  // opt/progress-only
+                ),                                                                                              // opt/progress-only
+            ),                                                                                                  // opt/progress-only
+        ),                                                                                                      // opt/progress-only
+    ),                                                                                                          // opt/progress-only
+    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                        // opt/protocol-timeout
     (                                                                                                        // opt/protocol-timeout
         PARSE_RULE_OPTION_NAME("protocol-timeout"),                                                          // opt/protocol-timeout
@@ -11256,6 +11280,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptPgVersionForce,                                                                                       // opt-resolve-order
     cfgOptProcess,                                                                                              // opt-resolve-order
     cfgOptProcessMax,                                                                                           // opt-resolve-order
+    cfgOptProgressOnly,                                                                                         // opt-resolve-order
     cfgOptProtocolTimeout,                                                                                      // opt-resolve-order
     cfgOptRaw,                                                                                                  // opt-resolve-order
     cfgOptRecurse,                                                                                              // opt-resolve-order

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -36,13 +36,25 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
+        StringList *argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+
+        StringList *argListTextProgressOnly = strLstDup(argListText);
+        hrnCfgArgRawZ(argListTextProgressOnly, cfgOptProgressOnly, "y");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("no stanzas have been created");
 
         TEST_RESULT_STR_Z(infoRender(), "[]", "json - repo but no stanzas");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+        TEST_RESULT_STR_Z(infoRender(), "[]", "json (progress only) - repo but no stanzas");
+
         HRN_CFG_LOAD(cfgCmdInfo, argListText);
         TEST_RESULT_STR_Z(infoRender(), "No stanzas exist in the repository.\n", "text - no stanzas");
+
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
+        TEST_RESULT_STR_Z(infoRender(), "No stanzas exist in the repository.\n", "text (progress only) - no stanzas");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("repo is still empty but stanza option is specified");
@@ -80,6 +92,27 @@ testRun(void)
             // {uncrustify_on}
             "json - empty repo, stanza option specified");
 
+        StringList *argListProgressOnlyStanzaOpt = strLstDup(argListProgressOnly);
+        hrnCfgArgRawZ(argListProgressOnlyStanzaOpt, cfgOptStanza, "stanza1");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"stanza1\","
+                    "\"status\":{"
+                        "\"code\":1,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"missing stanza path\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - empty repo, stanza option specified");
+
         StringList *argListTextStanzaOpt = strLstDup(argListText);
         hrnCfgArgRawZ(argListTextStanzaOpt, cfgOptStanza, "stanza1");
         HRN_CFG_LOAD(cfgCmdInfo, argListTextStanzaOpt);
@@ -89,12 +122,22 @@ testRun(void)
             "    status: error (missing stanza path)\n",
             "text - empty repo, stanza option specified");
 
+        StringList *argListTextProgressOnlyStanzaOpt = strLstDup(argListTextProgressOnly);
+        hrnCfgArgRawZ(argListTextProgressOnlyStanzaOpt, cfgOptStanza, "stanza1");
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (missing stanza path)\n",
+            "text (progress only) - empty repo, stanza option specified");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("stanza path exists but is empty");
 
         HRN_STORAGE_PATH_CREATE(storageRepoWrite(), STORAGE_REPO_ARCHIVE, .comment = "create repo stanza archive path");
         HRN_STORAGE_PATH_CREATE(storageRepoWrite(), STORAGE_REPO_BACKUP, .comment = "create repo stanza backup path");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             "stanza: stanza1\n"
@@ -102,7 +145,16 @@ testRun(void)
             "    cipher: none\n",
             "text - missing stanza data");
 
-        HRN_CFG_LOAD(cfgCmdInfo, argList);
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: ok\n",
+            "text (progress only) - missing stanza data");
+
+        HRN_CFG_LOAD(cfgCmdInfo, argListStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             // {uncrustify_off - indentation}
@@ -133,6 +185,27 @@ testRun(void)
             // {uncrustify_on}
             "json - missing stanza data");
 
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"stanza1\","
+                    "\"status\":{"
+                        "\"code\":0,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"ok\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - missing stanza data");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("backup.info file exists, but archive.info does not");
 
@@ -152,6 +225,7 @@ testRun(void)
             "2={\"db-catalog-version\":201608131,\"db-control-version\":960,\"db-system-id\":6569239123849665679"
             ",\"db-version\":\"9.6\"}\n");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             // {uncrustify_off - indentation}
@@ -343,6 +417,16 @@ testRun(void)
             "    status: error (missing stanza path)\n",
             "text - multi-repo, requested stanza missing on selected repo");
 
+        StringList *argList2ProgressOnly = strLstDup(argList2);
+        hrnCfgArgRawZ(argList2ProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argList2ProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (missing stanza path)\n",
+            "text (progress only) - multi-repo, requested stanza missing on selected repo");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("multi-repo - WAL segment on repo1");
 
@@ -366,6 +450,17 @@ testRun(void)
             "    db (current)\n"
             "        wal archive min/max (9.6): 000000030000000000000001/000000030000000000000001\n",
             "text - multi-repo, single stanza, one wal segment");
+
+        argList2ProgressOnly = strLstDup(argList2);
+        hrnCfgArgRawZ(argList2ProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argList2ProgressOnly);
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: ok\n",
+            "text (progress only) - multi-repo, single stanza, one wal segment");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("coverage for stanzaStatus branches && percent complete null");
@@ -590,6 +685,25 @@ testRun(void)
                     // {uncrustify_on}
                     "json - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                            "\"name\":\"stanza1\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":true}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (progress only) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
                 HRN_CFG_LOAD(cfgCmdInfo, argListText);
                 TEST_RESULT_STR_Z(
                     infoRender(),
@@ -615,6 +729,13 @@ testRun(void)
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
                     "text - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok (backup/expire running)\n",
+                    "text (progress only) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
@@ -1036,6 +1157,12 @@ testRun(void)
 
         StringList *argListMultiRepoJson = strLstDup(argListMultiRepo);
         hrnCfgArgRawZ(argListMultiRepoJson, cfgOptOutput, "json");
+
+        StringList *argListMultiRepoProgressOnly = strLstDup(argListMultiRepo);
+        hrnCfgArgRawZ(argListMultiRepoProgressOnly, cfgOptProgressOnly, "y");
+
+        StringList *argListMultiRepoJsonProgressOnly = strLstDup(argListMultiRepoJson);
+        hrnCfgArgRawZ(argListMultiRepoJsonProgressOnly, cfgOptProgressOnly, "y");
 
         HRN_FORK_BEGIN()
         {
@@ -1474,6 +1601,45 @@ testRun(void)
                     // {uncrustify_on}
                     "json - multiple stanzas, some with valid backups, archives in latest DB, backup lock held on one stanza");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListMultiRepoJsonProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                            "\"name\":\"stanza1\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "},"
+                        "{"
+                            "\"name\":\"stanza2\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":true,\"size\":3159000,\"size-cplt\":1435765}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "},"
+                        "{"
+                            "\"name\":\"stanza3\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (progress only) - multiple stanzas, some with valid backups, archives in latest DB, backup lock held on one stanza");
+
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
             }
@@ -1609,6 +1775,19 @@ testRun(void)
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo2: backup set size: 3MB, backup size: 3KB\n",
                     "text - multiple stanzas, multi-repo with valid backups, backup lock held on one stanza");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListMultiRepoProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok (backup/expire running - 65.27% complete)\n"
+                    "\n"
+                    "stanza: stanza2\n"
+                    "    status: ok (backup/expire running - 55.55% complete)\n"
+                    "\n"
+                    "stanza: stanza3\n"
+                    "    status: ok\n",
+                    "text (progress only) - multiple stanzas, multi-repo with valid backups, backup lock held on one stanza");
 
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
@@ -3411,6 +3590,16 @@ testRun(void)
             "    cipher: none\n",
             "text - invalid stanza");
 
+        StringList *argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: [invalid]\n"
+            "    status: error (other)\n",
+            "text (progress only) - invalid stanza");
+
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
@@ -3445,6 +3634,27 @@ testRun(void)
             // {uncrustify_on}
             "json - invalid stanza");
 
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptOutput, "json");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"[invalid]\","
+                    "\"status\":{"
+                        "\"code\":99,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"other\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - invalid stanza");
+
         argList = strLstNew();
         hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 1, TEST_PATH "/repo2");
         hrnCfgArgRawZ(argList, cfgOptStanza, "stanza1");
@@ -3457,6 +3667,16 @@ testRun(void)
             "            [PathOpenError] unable to list file info for path '" TEST_PATH "/repo2/backup': [13] Permission denied\n"
             "    cipher: none\n",
             "text - stanza requested");
+
+        argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (other)\n",
+            "text (progress only) - stanza requested");
 
         hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 2, TEST_PATH "/repo");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
@@ -3471,6 +3691,15 @@ testRun(void)
             "        repo2: error (missing stanza path)\n"
             "    cipher: none\n",
             "text - stanza repo structure exists");
+
+        hrnCfgArgKeyRawZ(argListProgressOnly, cfgOptRepoPath, 2, TEST_PATH "/repo");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (different across repos)\n",
+            "text (progress only) - stanza repo structure exists");
     }
 
     FUNCTION_HARNESS_RETURN_VOID();


### PR DESCRIPTION
The info command fetches backup.info, archive.info, and manifest files
from the repository. However, this operation may hang if a backup or
restore process is running in parallel. Since progress data is stored in
local lock files, accessing the repository is unnecessary when only
progress information is needed.

This patch introduces the --progress-only option, which restricts the
info command output to progress details without querying the repository.
The only remaining operations are scanning the folder structure to list
available stanzas and reading lock files.

Note: When using this option, the info command performs no additional
checks beyond verifying stanza availability.
