### PR TITLE
Take into account backup.info during pgbackrest verify

### DIFF
--- a/doc/src/meson.build
+++ b/doc/src/meson.build
@@ -40,6 +40,7 @@ src_doc = [
     '../../src/common/io/fd.c',
     '../../src/common/io/fdRead.c',
     '../../src/common/io/fdWrite.c',
+    '../../src/common/fork.c',
     '../../src/common/lock.c',
     '../../src/common/stat.c',
     '../../src/config/config.c',

--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -2,6 +2,18 @@
     <release-core-list>
         <release-improvement-list>
             <release-item>
+                <github-pull-request id="2752"/>
+                <github-issue id="2723"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="denis.garsh"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Add <file>backup.info</file> checks to <cmd>verify</cmd> command.</p>
+            </release-item>
+
+            <release-item>
                 <github-issue id="2732"/>
 
                 <release-item-contributor-list>

--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -2,12 +2,13 @@
     <release-core-list>
         <release-improvement-list>
             <release-item>
-                <github-pull-request id="2752"/>
                 <github-issue id="2723"/>
+                <github-pull-request id="2752"/>
 
                 <release-item-contributor-list>
                     <release-item-contributor id="denis.garsh"/>
                     <release-item-reviewer id="david.steele"/>
+                    <release-item-reviewer id="douglas.j.hunley"/>
                 </release-item-contributor-list>
 
                 <p>Add <file>backup.info</file> checks to <cmd>verify</cmd> command.</p>

--- a/src/command/archive/common.c
+++ b/src/command/archive/common.c
@@ -3,15 +3,11 @@ Archive Common
 ***********************************************************************************************************************************/
 #include <build.h>
 
-#include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "command/archive/common.h"
 #include "common/debug.h"
-#include "common/fork.h"
 #include "common/log.h"
 #include "common/memContext.h"
 #include "common/regExp.h"
@@ -232,67 +228,6 @@ archiveAsyncStatusOkWrite(const ArchiveMode archiveMode, const String *const wal
             warning == NULL ? NULL : BUFSTR(strNewFmt("0\n%s", strZ(warning))));
     }
     MEM_CONTEXT_TEMP_END();
-
-    FUNCTION_LOG_RETURN_VOID();
-}
-
-/**********************************************************************************************************************************/
-FN_EXTERN void
-archiveAsyncExec(const ArchiveMode archiveMode, const StringList *const commandExec)
-{
-    FUNCTION_LOG_BEGIN(logLevelDebug);
-        FUNCTION_LOG_PARAM(STRING_ID, archiveMode);
-        FUNCTION_LOG_PARAM(STRING_LIST, commandExec);
-    FUNCTION_LOG_END();
-
-    ASSERT(commandExec != NULL);
-
-    // Fork off the async process
-    const pid_t pid = forkSafe();
-
-    if (pid == 0)
-    {
-        // Disable logging and close log file
-        logClose();
-
-        // Detach from parent process
-        forkDetach();
-
-        // Close any open file descriptors above the standard three (stdin, stdout, stderr). Don't check the return value since we
-        // don't know which file descriptors are actually open (might be none). It's possible that there are open files >= 1024 but
-        // there is no easy way to detect that and this should give us enough descriptors to do our work.
-        for (int fd = 3; fd < 1024; fd++)
-            close(fd);
-
-        // Execute the binary. This statement will not return if it is successful. execvp() requires non-const parameters because it
-        // modifies them after the fork.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-qual"
-        THROW_ON_SYS_ERROR_FMT(
-            execvp(strZ(strLstGet(commandExec, 0)), UNCONSTIFY(char **, strLstPtr(commandExec))) == -1, ExecuteError,
-            "unable to execute asynchronous '%s'", archiveMode == archiveModeGet ? CFGCMD_ARCHIVE_GET : CFGCMD_ARCHIVE_PUSH);
-#pragma GCC diagnostic pop
-    }
-
-#ifdef DEBUG_EXEC_TIME
-    // Get the time to measure how long it takes for the forked process to exit
-    const TimeMSec timeBegin = timeMSec();
-#endif
-
-    // The process that was just forked should return immediately
-    int processStatus;
-
-    THROW_ON_SYS_ERROR(waitpid(pid, &processStatus, 0) == -1, ExecuteError, "unable to wait for forked process");
-
-    // The first fork should exit with success. If not, something went wrong during the second fork.
-    CHECK(ExecuteError, WIFEXITED(processStatus) && WEXITSTATUS(processStatus) == 0, "error on first fork");
-
-#ifdef DEBUG_EXEC_TIME
-    // If the process does not exit immediately then something probably went wrong with the double fork. It's possible that this
-    // test will fail on very slow systems so it may need to be tuned. The idea is to make sure that the waitpid() above is not
-    // waiting on the async process.
-    CHECK(AssertError, timeMSec() - timeBegin < 10, "the process does not exit immediately");
-#endif
 
     FUNCTION_LOG_RETURN_VOID();
 }

--- a/src/command/archive/common.h
+++ b/src/command/archive/common.h
@@ -79,9 +79,6 @@ FN_EXTERN void archiveAsyncStatusOkWrite(ArchiveMode archiveMode, const String *
 // Write an error status file
 FN_EXTERN void archiveAsyncStatusErrorWrite(ArchiveMode archiveMode, const String *walSegment, int code, const String *message);
 
-// Execute the async process. This function will only return in the calling process and the implementation is platform dependent.
-FN_EXTERN void archiveAsyncExec(ArchiveMode archiveMode, const StringList *commandExec);
-
 // Comparator function for sorting archive ids by the database history id (the number after the dash) e.g. 9.6-1, 10-2
 FN_EXTERN int archiveIdComparator(const void *item1, const void *item2);
 

--- a/src/command/archive/get/get.c
+++ b/src/command/archive/get/get.c
@@ -766,7 +766,7 @@ cmdArchiveGet(void)
                     cmdLockReleaseP();
 
                     // Execute the async process
-                    archiveAsyncExec(archiveModeGet, commandExec);
+                    cmdAsyncExec(CFGCMD_ARCHIVE_GET, commandExec);
 
                     // Mark the async process as forked so it doesn't get forked again. A single run of the async process should be
                     // enough to do the job, running it again won't help anything.

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -372,7 +372,7 @@ cmdArchivePush(void)
                     cmdLockReleaseP();
 
                     // Execute the async process
-                    archiveAsyncExec(archiveModePush, commandExec);
+                    cmdAsyncExec(CFGCMD_ARCHIVE_PUSH, commandExec);
 
                     // Mark the async process as forked so it doesn't get forked again. A single run of the async process should be
                     // enough to do the job, running it again won't help anything.

--- a/src/command/command.c
+++ b/src/command/command.c
@@ -4,10 +4,14 @@ Common Command Routines
 #include <build.h>
 
 #include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "command/command.h"
 #include "common/debug.h"
+#include "common/fork.h"
 #include "common/log.h"
 #include "common/memContext.h"
 #include "common/stat.h"
@@ -232,6 +236,67 @@ cmdEnd(const int code, const String *const errorMessage)
 
     // Reset timeBegin in case there is another command following this one
     timeBegin = timeMSec();
+
+    FUNCTION_LOG_RETURN_VOID();
+}
+
+/**********************************************************************************************************************************/
+FN_EXTERN void
+cmdAsyncExec(const char *const command, const StringList *const commandExec)
+{
+    FUNCTION_LOG_BEGIN(logLevelDebug);
+        FUNCTION_LOG_PARAM(STRINGZ, command);
+        FUNCTION_LOG_PARAM(STRING_LIST, commandExec);
+    FUNCTION_LOG_END();
+
+    ASSERT(commandExec != NULL);
+
+    // Fork off the async process
+    const pid_t pid = forkSafe();
+
+    if (pid == 0)
+    {
+        // Disable logging and close log file
+        logClose();
+
+        // Detach from parent process
+        forkDetach();
+
+        // Close any open file descriptors above the standard three (stdin, stdout, stderr). Don't check the return value since we
+        // don't know which file descriptors are actually open (might be none). It's possible that there are open files >= 1024 but
+        // there is no easy way to detect that and this should give us enough descriptors to do our work.
+        for (int fd = 3; fd < 1024; fd++)
+            close(fd);
+
+        // Execute the binary. This statement will not return if it is successful. execvp() requires non-const parameters because it
+        // modifies them after the fork.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+        THROW_ON_SYS_ERROR_FMT(
+            execvp(strZ(strLstGet(commandExec, 0)), UNCONSTIFY(char **, strLstPtr(commandExec))) == -1, ExecuteError,
+            "unable to execute asynchronous '%s'", command);
+#pragma GCC diagnostic pop
+    }
+
+#ifdef DEBUG_EXEC_TIME
+    // Get the time to measure how long it takes for the forked process to exit
+    const TimeMSec timeBegin = timeMSec();
+#endif
+
+    // The process that was just forked should return immediately
+    int processStatus;
+
+    THROW_ON_SYS_ERROR(waitpid(pid, &processStatus, 0) == -1, ExecuteError, "unable to wait for forked process");
+
+    // The first fork should exit with success. If not, something went wrong during the second fork.
+    CHECK(ExecuteError, WIFEXITED(processStatus) && WEXITSTATUS(processStatus) == 0, "error on first fork");
+
+#ifdef DEBUG_EXEC_TIME
+    // If the process does not exit immediately then something probably went wrong with the double fork. It's possible that this
+    // test will fail on very slow systems so it may need to be tuned. The idea is to make sure that the waitpid() above is not
+    // waiting on the async process.
+    CHECK(AssertError, timeMSec() - timeBegin < 10, "the process does not exit immediately");
+#endif
 
     FUNCTION_LOG_RETURN_VOID();
 }

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -4,7 +4,7 @@ Common Command Routines
 #ifndef COMMAND_COMMAND_H
 #define COMMAND_COMMAND_H
 
-#include "common/type/string.h"
+#include "common/type/stringList.h"
 
 /***********************************************************************************************************************************
 Functions
@@ -21,5 +21,8 @@ FN_EXTERN const String *cmdOption(void);
 
 // End the command
 FN_EXTERN void cmdEnd(int code, const String *errorMessage);
+
+// Execute an async process. This function will only return in the calling process and the implementation is platform dependent.
+FN_EXTERN void cmdAsyncExec(const char *command, const StringList *commandExec);
 
 #endif

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1675,9 +1675,7 @@ verifyProcess(const bool verboseText)
                     const String *const label = strLstGet(jobData.backupList, repoIdx);
 
                     if (!infoBackupLabelExists(backupInfo, label))
-                    {
-                        LOG_WARN_FMT("backup '%s' is not described in " INFO_BACKUP_FILE,strZ(label));
-                    }
+                        LOG_WARN_FMT("backup '%s' is not described in " INFO_BACKUP_FILE, strZ(label));
                 }
             }
 
@@ -1706,17 +1704,15 @@ verifyProcess(const bool verboseText)
             // Check if backup.info contains backups not on disk and add them for processing.
             if (backupLabel == NULL)
             {
-                const StringList *infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);
+                const StringList *const infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);
 
                 for (unsigned int infoIdx = 0; infoIdx < strLstSize(infoBackupLabelList); infoIdx++)
                 {
-                    const String *infoLabel = strLstGet(infoBackupLabelList, infoIdx);
+                    const String *const infoLabel = strLstGet(infoBackupLabelList, infoIdx);
 
                     if (strLstFindIdxP(jobData.backupList, infoLabel) == LIST_NOT_FOUND)
                     {
-                        LOG_WARN_FMT(
-                            "backup '%s' exists in " INFO_BACKUP_FILE " but was not found on disk",
-                            strZ(infoLabel));
+                        LOG_WARN_FMT("backup '%s' exists in " INFO_BACKUP_FILE " but was not found on disk", strZ(infoLabel));
 
                         MEM_CONTEXT_BEGIN(jobData.memContext)
                         {
@@ -1725,6 +1721,7 @@ verifyProcess(const bool verboseText)
                         MEM_CONTEXT_END();
                     }
                 }
+
                 jobData.backupList = strLstSort(jobData.backupList, sortOrderAsc);
             }
 

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1675,7 +1675,7 @@ verifyProcess(const bool verboseText)
                     const String *const label = strLstGet(jobData.backupList, repoIdx);
 
                     if (!infoBackupLabelExists(backupInfo, label))
-                        LOG_WARN_FMT("backup '%s' is not described in " INFO_BACKUP_FILE, strZ(label));
+                        LOG_WARN_FMT("backup '%s' found in the repository but not in " INFO_BACKUP_FILE, strZ(label));
                 }
             }
 
@@ -1712,7 +1712,7 @@ verifyProcess(const bool verboseText)
 
                     if (strLstFindIdxP(jobData.backupList, infoLabel) == LIST_NOT_FOUND)
                     {
-                        LOG_WARN_FMT("backup '%s' exists in " INFO_BACKUP_FILE " but was not found on disk", strZ(infoLabel));
+                        LOG_WARN_FMT("backup '%s' found in " INFO_BACKUP_FILE " but not in the repository", strZ(infoLabel));
 
                         MEM_CONTEXT_BEGIN(jobData.memContext)
                         {

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1668,6 +1668,17 @@ verifyProcess(const bool verboseText)
             {
                 jobData.backupList = strLstSort(
                     storageListP(storage, STORAGE_REPO_BACKUP_STR, .expression = backupRegExpStr), sortOrderAsc);
+
+                // Warn if backups on disk are not described in backup.info
+                for (unsigned int repoIdx = 0; repoIdx < strLstSize(jobData.backupList); repoIdx++)
+                {
+                    const String *const label = strLstGet(jobData.backupList, repoIdx);
+
+                    if (!infoBackupLabelExists(backupInfo, label))
+                    {
+                        LOG_WARN_FMT("backup '%s' is not described in " INFO_BACKUP_FILE,strZ(label));
+                    }
+                }
             }
 
             if (!backupLabelInvalid && backupLabel != NULL && strLstEmpty(jobData.backupList))
@@ -1691,6 +1702,31 @@ verifyProcess(const bool verboseText)
             // Check for block map dependencies if --set option is specified
             if (!backupLabelInvalid && backupLabel != NULL)
                 verifyBackupSet(&jobData, backupLabel);
+
+            // Check if backup.info contains backups not on disk and add them for processing.
+            if (backupLabel == NULL)
+            {
+                const StringList *infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);
+
+                for (unsigned int infoIdx = 0; infoIdx < strLstSize(infoBackupLabelList); infoIdx++)
+                {
+                    const String *infoLabel = strLstGet(infoBackupLabelList, infoIdx);
+
+                    if (strLstFindIdxP(jobData.backupList, infoLabel) == LIST_NOT_FOUND)
+                    {
+                        LOG_WARN_FMT(
+                            "backup '%s' exists in " INFO_BACKUP_FILE " but was not found on disk",
+                            strZ(infoLabel));
+
+                        MEM_CONTEXT_BEGIN(jobData.memContext)
+                        {
+                            strLstAdd(jobData.backupList, strDup(infoLabel));
+                        }
+                        MEM_CONTEXT_END();
+                    }
+                }
+                jobData.backupList = strLstSort(jobData.backupList, sortOrderAsc);
+            }
 
             // Only begin processing if there are some archives or backups in the repo
             if (!backupLabelInvalid && (!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList)))

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1669,7 +1669,9 @@ verifyProcess(const bool verboseText)
                 jobData.backupList = strLstSort(
                     storageListP(storage, STORAGE_REPO_BACKUP_STR, .expression = backupRegExpStr), sortOrderAsc);
 
-                // Warn if backups on disk are not described in backup.info
+                // Warn if backups in the repository are not described in backup.info. Do not add them for processing since it is
+                // possible for backups to exist in the repository but not in backup.info if an error occurs while backups are being
+                // expired.
                 for (unsigned int repoIdx = 0; repoIdx < strLstSize(jobData.backupList); repoIdx++)
                 {
                     const String *const label = strLstGet(jobData.backupList, repoIdx);
@@ -1701,7 +1703,7 @@ verifyProcess(const bool verboseText)
             if (!backupLabelInvalid && backupLabel != NULL)
                 verifyBackupSet(&jobData, backupLabel);
 
-            // Check if backup.info contains backups not on disk and add them for processing
+            // Check if backup.info contains backups not found in the repository and add them for processing
             if (backupLabel == NULL)
             {
                 const StringList *const infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1701,7 +1701,7 @@ verifyProcess(const bool verboseText)
             if (!backupLabelInvalid && backupLabel != NULL)
                 verifyBackupSet(&jobData, backupLabel);
 
-            // Check if backup.info contains backups not on disk and add them for processing.
+            // Check if backup.info contains backups not on disk and add them for processing
             if (backupLabel == NULL)
             {
                 const StringList *const infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1715,12 +1715,7 @@ verifyProcess(const bool verboseText)
                     if (strLstFindIdxP(jobData.backupList, infoLabel) == LIST_NOT_FOUND)
                     {
                         LOG_WARN_FMT("backup '%s' found in " INFO_BACKUP_FILE " but not in the repository", strZ(infoLabel));
-
-                        MEM_CONTEXT_BEGIN(jobData.memContext)
-                        {
-                            strLstAdd(jobData.backupList, strDup(infoLabel));
-                        }
-                        MEM_CONTEXT_END();
+                        strLstAdd(jobData.backupList, infoLabel);
                     }
                 }
 

--- a/src/common/stackTrace.c
+++ b/src/common/stackTrace.c
@@ -8,7 +8,6 @@ Stack Trace Handler
 #include <string.h>
 
 #ifdef HAVE_LIBBACKTRACE
-    #include <backtrace-supported.h>
     #include <backtrace.h>
 #endif
 

--- a/test/define.yaml
+++ b/test/define.yaml
@@ -860,6 +860,7 @@ unit:
           - command/archive/push/file
           - command/archive/push/protocol
           - command/archive/push/push
+          - command/command
 
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: stanza

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -107,6 +107,15 @@ testRun(void)
         "\n"                                                                                                                       \
         TEST_BACKUP_DB2_HISTORY
 
+    #define TEST_NO_CURRENT_BACKUP                                                                                                 \
+        "[db]\n"                                                                                                                   \
+        TEST_BACKUP_DB2_11                                                                                                         \
+        "\n"                                                                                                                       \
+        "[db:history]\n"                                                                                                           \
+        TEST_BACKUP_DB1_HISTORY                                                                                                    \
+        "\n"                                                                                                                       \
+        TEST_BACKUP_DB2_HISTORY
+
     #define TEST_ARCHIVE_INFO_BASE                                                                                                 \
         "[db]\n"                                                                                                                   \
         "db-id=1\n"                                                                                                                \
@@ -761,7 +770,7 @@ testRun(void)
         TEST_TITLE("backup.info and copy valid but checksum mismatch, archive.info checksum invalid, archive.info copy valid");
 
         HRN_INFO_PUT(
-            storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO_MULTI_HISTORY_BASE, .comment = "valid backup.info");
+            storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_NO_CURRENT_BACKUP, .comment = "valid backup.info");
         HRN_STORAGE_PUT_Z(
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE, TEST_INVALID_BACKREST_INFO, .comment = "invalid archive.info");
         HRN_INFO_PUT(
@@ -796,7 +805,7 @@ testRun(void)
         TEST_TITLE("backup.info and copy valid and checksums match, archive.info and copy valid, but checksum mismatch");
 
         HRN_INFO_PUT(
-            storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO_MULTI_HISTORY_BASE,
+            storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_NO_CURRENT_BACKUP,
             .comment = "valid backup.info.copy");
         HRN_INFO_PUT(
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE, .comment = "valid archive.info");
@@ -914,15 +923,6 @@ testRun(void)
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("valid info files, WAL files present, no backups");
-
-        #define TEST_NO_CURRENT_BACKUP                                                                                             \
-            "[db]\n"                                                                                                               \
-            TEST_BACKUP_DB2_11                                                                                                     \
-            "\n"                                                                                                                   \
-            "[db:history]\n"                                                                                                       \
-            TEST_BACKUP_DB1_HISTORY                                                                                                \
-            "\n"                                                                                                                   \
-            TEST_BACKUP_DB2_HISTORY
 
         HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_NO_CURRENT_BACKUP, .comment = "no current backups");
         HRN_INFO_PUT(
@@ -1246,6 +1246,44 @@ testRun(void)
             storageRepoIdxWrite(0), STORAGE_REPO_BACKUP "/20181119-153000F",
             .comment = "create empty backup path for newest backup so in-progress");
 
+        #define TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                \
+            "20181119-152900F_20181119-152909D={"                                                                                  \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000010000000000000006\",\"backup-archive-stop\":\"000000010000000000000007\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #define TEST_BACKUP_DB1_CURRENT_FULL4                                                                                      \
+            "20181119-152810F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL1                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL2                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB1_CURRENT_FULL4                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
+
         // Set log level to capture ranges
         harnessLogLevelSet(logLevelDetail);
 
@@ -1267,6 +1305,8 @@ testRun(void)
         // Check output of verify command stored in file
         TEST_STORAGE_GET(storageTest, strZ(stdoutFile), "", .remove = true);
         TEST_RESULT_LOG(
+            "P00   WARN: backup '20181119-153000F' is not described in backup.info\n"
+            "P00   WARN: backup '20181119-152138F' exists in backup.info but was not found on disk\n"
             "P00 DETAIL: archive path '9.6-1' is empty\n"
             "P00 DETAIL: path '11-2/0000000100000000' does not contain any valid WAL to be processed\n"
             "P01   INFO: invalid checksum"
@@ -1279,6 +1319,10 @@ testRun(void)
             "/11-2/0000000200000008/000000020000000800000003-656817043007aa2100c44c712bcb456db705dab9' for read:"
             " [13] Permission denied\n"
             "            [RETRY DETAIL OMITTED]\n"
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152138F/backup.manifest' for read\n"
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152138F/backup.manifest.copy'"
+            " for read\n"
+            "P00 DETAIL: manifest missing for '20181119-152138F' - backup may have expired\n"
             "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152800F/backup.manifest' for read\n"
             "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152800F/backup.manifest.copy'"
             " for read\n"
@@ -1301,6 +1345,7 @@ testRun(void)
             "            status: error\n"
             "              archiveId: 11-2, total WAL checked: 8, total valid WAL: 5\n"
             "                checksum invalid: 1, size invalid: 1, other: 1\n"
+            "              backup: 20181119-152138F, status: manifest missing, total files checked: 0, total valid files: 0\n"
             "              backup: 20181119-152800F, status: manifest missing, total files checked: 0, total valid files: 0\n"
             "              backup: 20181119-152810F, status: invalid, total files checked: 0, total valid files: 0\n"
             "              backup: 20181119-152900F, status: invalid, total files checked: 3, total valid files: 2\n"
@@ -1324,6 +1369,7 @@ testRun(void)
             "status: error\n"
             "  archiveId: 11-2, total WAL checked: 8, total valid WAL: 5\n"
             "    checksum invalid: 1, size invalid: 1, other: 1\n"
+            "  backup: 20181119-152138F, status: manifest missing, total files checked: 0, total valid files: 0\n"
             "  backup: 20181119-152800F, status: manifest missing, total files checked: 0, total valid files: 0\n"
             "  backup: 20181119-152810F, status: invalid, total files checked: 0, total valid files: 0\n"
             "  backup: 20181119-152900F, status: invalid, total files checked: 3, total valid files: 2\n"
@@ -1331,6 +1377,8 @@ testRun(void)
             "  backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 6, total valid files: 3\n"
             "    missing: 1, checksum invalid: 1, other: 1", "verify text output, not verbose, with verify failures");
         TEST_RESULT_LOG(
+            "P00   WARN: backup '20181119-153000F' is not described in backup.info\n"
+            "P00   WARN: backup '20181119-152138F' exists in backup.info but was not found on disk\n"
             "P01   INFO: invalid checksum"
             " '11-2/0000000200000007/000000020000000700000FFD-a6e1a64f0813352bc2e97f116a1800377e17d2e4.gz'\n"
             "P01   INFO: invalid size"
@@ -1356,16 +1404,6 @@ testRun(void)
         StringList *argList = strLstDup(argListBase);
         HRN_CFG_LOAD(cfgCmdVerify, argList);
 
-        #define TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                \
-            "20181119-152900F_20181119-152909D={"                                                                                  \
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
-            "\"backup-archive-start\":\"000000010000000000000006\",\"backup-archive-stop\":\"000000010000000000000007\","          \
-            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
-            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
-            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-
         #define TEST_BACKUP_DB2_CURRENT_FULL1                                                                                      \
             "20201119-163000F={"                                                                                                   \
             "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
@@ -1385,11 +1423,11 @@ testRun(void)
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE INFO_COPY_EXT, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE,
             .comment = "valid archive.info.copy");
 
+        #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
-            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -1485,6 +1523,24 @@ testRun(void)
         // Set process max to 1 and add more files to check so first backup completes before second is checked
         hrnCfgArgRawZ(argList, cfgOptProcessMax, "1");
         HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        #undef TEST_BACKUP_INFO
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
 
         String *manifestContent = strNewFmt(
             TEST_MANIFEST_HEADER
@@ -1650,11 +1706,11 @@ testRun(void)
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE INFO_COPY_EXT, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE,
             .comment = "valid archive.info.copy");
 
+        #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
-            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -1998,11 +2054,22 @@ testRun(void)
             "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
             "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
 
+        #define TEST_BACKUP_DB2_CURRENT_FULL2                                                                                      \
+            "20181119-153300F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000050000000800000003\",\"backup-archive-stop\":\"000000050000000800000004\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":2,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
         #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL2                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -2227,6 +2294,35 @@ testRun(void)
                           STORAGE_REPO_BACKUP "/20181119-153400F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT,
                           strZ(manifestContent),
                           .comment = "invalid manifest copy - full");
+
+        #define TEST_BACKUP_DB2_CURRENT_FULL3                                                                                      \
+            "20181119-153400F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000050000000800000003\",\"backup-archive-stop\":\"000000050000000800000004\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":2,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #undef TEST_BACKUP_INFO
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL2                                                                                          \
+            TEST_BACKUP_DB2_CURRENT_FULL3                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
 
         TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -107,6 +107,15 @@ testRun(void)
         "\n"                                                                                                                       \
         TEST_BACKUP_DB2_HISTORY
 
+    #define TEST_NO_CURRENT_BACKUP                                                                                                 \
+        "[db]\n"                                                                                                                   \
+        TEST_BACKUP_DB2_11                                                                                                         \
+        "\n"                                                                                                                       \
+        "[db:history]\n"                                                                                                           \
+        TEST_BACKUP_DB1_HISTORY                                                                                                    \
+        "\n"                                                                                                                       \
+        TEST_BACKUP_DB2_HISTORY
+
     #define TEST_ARCHIVE_INFO_BASE                                                                                                 \
         "[db]\n"                                                                                                                   \
         "db-id=1\n"                                                                                                                \
@@ -761,7 +770,7 @@ testRun(void)
         TEST_TITLE("backup.info and copy valid but checksum mismatch, archive.info checksum invalid, archive.info copy valid");
 
         HRN_INFO_PUT(
-            storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO_MULTI_HISTORY_BASE, .comment = "valid backup.info");
+            storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_NO_CURRENT_BACKUP, .comment = "valid backup.info");
         HRN_STORAGE_PUT_Z(
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE, TEST_INVALID_BACKREST_INFO, .comment = "invalid archive.info");
         HRN_INFO_PUT(
@@ -796,7 +805,7 @@ testRun(void)
         TEST_TITLE("backup.info and copy valid and checksums match, archive.info and copy valid, but checksum mismatch");
 
         HRN_INFO_PUT(
-            storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO_MULTI_HISTORY_BASE,
+            storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_NO_CURRENT_BACKUP,
             .comment = "valid backup.info.copy");
         HRN_INFO_PUT(
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE, .comment = "valid archive.info");
@@ -914,15 +923,6 @@ testRun(void)
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("valid info files, WAL files present, no backups");
-
-        #define TEST_NO_CURRENT_BACKUP                                                                                             \
-            "[db]\n"                                                                                                               \
-            TEST_BACKUP_DB2_11                                                                                                     \
-            "\n"                                                                                                                   \
-            "[db:history]\n"                                                                                                       \
-            TEST_BACKUP_DB1_HISTORY                                                                                                \
-            "\n"                                                                                                                   \
-            TEST_BACKUP_DB2_HISTORY
 
         HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_NO_CURRENT_BACKUP, .comment = "no current backups");
         HRN_INFO_PUT(
@@ -1246,6 +1246,44 @@ testRun(void)
             storageRepoIdxWrite(0), STORAGE_REPO_BACKUP "/20181119-153000F",
             .comment = "create empty backup path for newest backup so in-progress");
 
+        #define TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                \
+            "20181119-152900F_20181119-152909D={"                                                                                  \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000010000000000000006\",\"backup-archive-stop\":\"000000010000000000000007\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #define TEST_BACKUP_DB1_CURRENT_FULL4                                                                                      \
+            "20181119-152810F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL1                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL2                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB1_CURRENT_FULL4                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
+
         // Set log level to capture ranges
         harnessLogLevelSet(logLevelDetail);
 
@@ -1356,16 +1394,6 @@ testRun(void)
         StringList *argList = strLstDup(argListBase);
         HRN_CFG_LOAD(cfgCmdVerify, argList);
 
-        #define TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                \
-            "20181119-152900F_20181119-152909D={"                                                                                  \
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
-            "\"backup-archive-start\":\"000000010000000000000006\",\"backup-archive-stop\":\"000000010000000000000007\","          \
-            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
-            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
-            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-
         #define TEST_BACKUP_DB2_CURRENT_FULL1                                                                                      \
             "20201119-163000F={"                                                                                                   \
             "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
@@ -1385,11 +1413,11 @@ testRun(void)
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE INFO_COPY_EXT, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE,
             .comment = "valid archive.info.copy");
 
+        #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
-            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -1485,6 +1513,24 @@ testRun(void)
         // Set process max to 1 and add more files to check so first backup completes before second is checked
         hrnCfgArgRawZ(argList, cfgOptProcessMax, "1");
         HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        #undef TEST_BACKUP_INFO
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
 
         String *manifestContent = strNewFmt(
             TEST_MANIFEST_HEADER
@@ -1650,11 +1696,11 @@ testRun(void)
             storageRepoWrite(), INFO_ARCHIVE_PATH_FILE INFO_COPY_EXT, TEST_ARCHIVE_INFO_MULTI_HISTORY_BASE,
             .comment = "valid archive.info.copy");
 
+        #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
-            TEST_BACKUP_DB2_CURRENT_FULL1                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -1998,11 +2044,22 @@ testRun(void)
             "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
             "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
 
+        #define TEST_BACKUP_DB2_CURRENT_FULL2                                                                                      \
+            "20181119-153300F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000050000000800000003\",\"backup-archive-stop\":\"000000050000000800000004\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":2,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
         #undef TEST_BACKUP_INFO
         #define TEST_BACKUP_INFO                                                                                                   \
             "[backup:current]\n"                                                                                                   \
             TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
             TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL2                                                                                          \
             "\n"                                                                                                                   \
             "[db]\n"                                                                                                               \
             TEST_BACKUP_DB2_11                                                                                                     \
@@ -2227,6 +2284,35 @@ testRun(void)
                           STORAGE_REPO_BACKUP "/20181119-153400F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT,
                           strZ(manifestContent),
                           .comment = "invalid manifest copy - full");
+
+        #define TEST_BACKUP_DB2_CURRENT_FULL3                                                                                      \
+            "20181119-153400F={"                                                                                                   \
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","                                                              \
+            "\"backup-archive-start\":\"000000050000000800000003\",\"backup-archive-stop\":\"000000050000000800000004\","          \
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"                                           \
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"                                                   \
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","                 \
+            "\"db-id\":2,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"             \
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+
+        #undef TEST_BACKUP_INFO
+        #define TEST_BACKUP_INFO                                                                                                   \
+            "[backup:current]\n"                                                                                                   \
+            TEST_BACKUP_DB1_CURRENT_FULL3                                                                                          \
+            TEST_BACKUP_DB1_CURRENT_FULL3_DIFF1                                                                                    \
+            TEST_BACKUP_DB2_CURRENT_FULL2                                                                                          \
+            TEST_BACKUP_DB2_CURRENT_FULL3                                                                                          \
+            "\n"                                                                                                                   \
+            "[db]\n"                                                                                                               \
+            TEST_BACKUP_DB2_11                                                                                                     \
+            "\n"                                                                                                                   \
+            "[db:history]\n"                                                                                                       \
+            TEST_BACKUP_DB1_HISTORY                                                                                                \
+            "\n"                                                                                                                   \
+            TEST_BACKUP_DB2_HISTORY
+
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
+        HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
 
         TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -1305,8 +1305,8 @@ testRun(void)
         // Check output of verify command stored in file
         TEST_STORAGE_GET(storageTest, strZ(stdoutFile), "", .remove = true);
         TEST_RESULT_LOG(
-            "P00   WARN: backup '20181119-153000F' is not described in backup.info\n"
-            "P00   WARN: backup '20181119-152138F' exists in backup.info but was not found on disk\n"
+            "P00   WARN: backup '20181119-153000F' found in the repository but not in backup.info\n"
+            "P00   WARN: backup '20181119-152138F' found in backup.info but not in the repository\n"
             "P00 DETAIL: archive path '9.6-1' is empty\n"
             "P00 DETAIL: path '11-2/0000000100000000' does not contain any valid WAL to be processed\n"
             "P01   INFO: invalid checksum"
@@ -1377,8 +1377,8 @@ testRun(void)
             "  backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 6, total valid files: 3\n"
             "    missing: 1, checksum invalid: 1, other: 1", "verify text output, not verbose, with verify failures");
         TEST_RESULT_LOG(
-            "P00   WARN: backup '20181119-153000F' is not described in backup.info\n"
-            "P00   WARN: backup '20181119-152138F' exists in backup.info but was not found on disk\n"
+            "P00   WARN: backup '20181119-153000F' found in the repository but not in backup.info\n"
+            "P00   WARN: backup '20181119-152138F' found in backup.info but not in the repository\n"
             "P01   INFO: invalid checksum"
             " '11-2/0000000200000007/000000020000000700000FFD-a6e1a64f0813352bc2e97f116a1800377e17d2e4.gz'\n"
             "P01   INFO: invalid size"

--- a/test/src/module/common/ioTlsTest.c
+++ b/test/src/module/common/ioTlsTest.c
@@ -637,7 +637,9 @@ testRun(void)
             // Not musl libc
             "unable to get address for '99.99.99.99.99': [-2] Name or service not known",
             // Musl libc
-            "unable to get address for '99.99.99.99.99': [-2] Name does not resolve");
+            "unable to get address for '99.99.99.99.99': [-2] Name does not resolve",
+            // WSL
+            "unable to get address for '99.99.99.99.99': [-3] Temporary failure in name resolution");
 
         // Set TLS client timeout higher than socket timeout to ensure that TLS retries are covered
         TEST_ASSIGN(


### PR DESCRIPTION
Verify currently checks only backup directories present in the repository and does not validate consistency with backup.info. As a result, discrepancies between the repo contents and backup.info may go unnoticed.

Warn if a backup directory exists but is not described in backup.info. Warn if a backup is listed in backup.info but missing on disk. Add backups found only in backup.info (but not on disk) to the processing list so that verify command reports their status as manifest missing.